### PR TITLE
Adapt for Apple M2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@ install-deps:
 
 install-dev:
 	ansible-galaxy collection install . --force
+
+install-seldon-v2:
+	pip install -r requirements_kind.txt
+	ansible-playbook playbooks/kind.yaml

--- a/playbooks/kind.yaml
+++ b/playbooks/kind.yaml
@@ -7,6 +7,8 @@
   vars:
     kind_cluster_name: ansible
     # For compatible version of image for each kind version please see https://github.com/kubernetes-sigs/kind/releases    
-    kind_version: v0.14.0
-    kind_image_version: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5b
+    kind_version: v0.17.0
+    kind_image_version: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    kind_config_file: null
     kind_kubectl_default_namespace: seldon
+    kind_url:  "https://kind.sigs.k8s.io/dl/{{ kind_version }}/kind-darwin-arm64"

--- a/requirements_kind.txt
+++ b/requirements_kind.txt
@@ -1,0 +1,4 @@
+ansible==6.6.0
+ansible-core==2.13.7
+docker==6.0.1
+kubernetes==25.3.0


### PR DESCRIPTION
Adapt `Ansible` playbook for installation of `Seldon V2` on a local `Kubernetes` cluster on Apple Silicon (M2)